### PR TITLE
Update

### DIFF
--- a/cors.json
+++ b/cors.json
@@ -1,6 +1,6 @@
 [
     {
-        "origin": ["https://scottsrl.netlify.app","http://localhost:8888"],
+        "origin": ["https://scottsrl.netlify.app","http://localhost:8888","https://scott.srl"],
         "method": ["GET"],
         "maxAgeSeconds": 3600
     }

--- a/src/components/createpost/create-post-style.css
+++ b/src/components/createpost/create-post-style.css
@@ -1,6 +1,10 @@
+#modifyAddress {
+    width: 25px;
+}
+
 .lbl {
     text-align: right;
-    width: 100px;
+    /* width: 100px; */
     white-space: nowrap;
 }
 

--- a/src/components/createpost/create-post.jsx
+++ b/src/components/createpost/create-post.jsx
@@ -49,24 +49,26 @@ const CreatePost = () => {
     };
 
 
-    const [post, setPost] = useState({
-        name: '',
-        coordinates: '',
-        description: '',
-        address: '',
-        floorSpace: '',
-        locali: '',
-        city: '',
-        box: '',
-        other: '',
-        video: '',
-        nameDoc1: '',
-        nameDoc2: '',
-        nameDoc3: '',
-        nameDoc4: '',
-        nameDoc5: ''
-        // other fields as needed
-    });
+    // const [post, setPost] = useState({
+    //     name: '',
+    //     coordinates: '',
+    //     description: '',
+    //     address: '',
+    //     floorSpace: '',
+    //     locali: '',
+    //     city: '',
+    //     box: '',
+    //     other: '',
+    //     video: '',
+    //     nameDoc1: '',
+    //     nameDoc2: '',
+    //     nameDoc3: '',
+    //     nameDoc4: '',
+    //     nameDoc5: ''
+    //     // other fields as needed
+    // });
+    const [post, setPost] = useState('');
+
     const [doc1, setdoc1] = useState(null);
     const [doc2, setdoc2] = useState(null);
     const [doc3, setdoc3] = useState(null);
@@ -79,8 +81,6 @@ const CreatePost = () => {
     const handleChange = (e) => {
         setSuccessMessage('');
         setPost({ ...post, [e.target.id]: e.target.value });
-        console.log(e.target.id)
-        console.log(e.target.value)
     };
 
     const handleFileChange = (e) => {
@@ -113,6 +113,7 @@ const CreatePost = () => {
         formData.append('coordinates', [coordinates.lat, coordinates.lng]);
         // Special case for address
         formData.append('address', removeLastWordAndComma(address));
+
 
         if (doc1) formData.append('doc1', doc1);
         if (doc2) formData.append('doc2', doc2);
@@ -163,6 +164,7 @@ const CreatePost = () => {
 
 
     let squareMeters = 'm\u00B2';
+    const [isCheckboxChecked, setCheckboxChecked] = useState(false);
 
     if (!isLoaded) return <div>Loading...</div>;
 
@@ -214,12 +216,25 @@ const CreatePost = () => {
                                 />
                             </Autocomplete>
                             </td>
-                            {/* <td><input className="fld" onChange={handleChange}  id="address" type="text" placeholder="Via/Piazza/Strada" /></td> */}
                         </tr>
-                        {/* <tr>
-                            <td className="lbl"><label htmlFor="floorSpace">Superficie:</label></td>
-                            <td><input className="fld" onChange={handleChange}  id="floorSpace" type="text" placeholder={squareMeters}/></td>
-                        </tr> */}
+                        {address && (
+                            <tr>
+                            <td className="lbl" style={{ display: 'flex', alignItems: 'center' }}>
+                                <label htmlFor="modifyAddress" style={{ marginRight: '0.5em' }}>Modifica indirizzo</label>
+                                <input type="checkbox" id="modifyAddress" onChange={() => {
+                                    setCheckboxChecked(!isCheckboxChecked);
+                                    if (isCheckboxChecked) {
+                                        setPost(prevPost => ({ ...prevPost, altAddress: '' }));
+                                    }
+                                }} />
+                            </td>
+                                <td>
+                                    {isCheckboxChecked && (
+                                        <input style={{ width: '100%'}} onChange={handleChange}  id="altAddress" type="text" placeholder={address ? address : "Via/Piazza/Strada"} />
+                                    )}
+                                </td>
+                            </tr>
+                        )}
                     </tbody>
                 </table>
             </div>

--- a/src/components/createpost/create-post.jsx
+++ b/src/components/createpost/create-post.jsx
@@ -195,7 +195,7 @@ const CreatePost = () => {
                         </tr>
                         <tr>
                             <td className="lbl"><label htmlFor="description">Descrizione:</label></td>
-                            <td><textarea style={{ width: '100%'}} onChange={handleChange}  id="description" type="text" placeholder="..." /></td>
+                            <td><textarea style={{ width: '100%'}} onChange={handleChange}  id="description" type="text" placeholder="..." required/></td>
                             <td></td>
                         </tr>
                         <tr>

--- a/src/components/createpost/create-post.jsx
+++ b/src/components/createpost/create-post.jsx
@@ -74,6 +74,12 @@ const CreatePost = () => {
     const [doc3, setdoc3] = useState(null);
     const [doc4, setdoc4] = useState(null);
     const [doc5, setdoc5] = useState(null);
+    const [doc1Name, setdoc1name] = useState(null);
+    const [doc2Name, setdoc2name] = useState(null);
+    const [doc3Name, setdoc3name] = useState(null);
+    const [doc4Name, setdoc4name] = useState(null);
+    const [doc5Name, setdoc5name] = useState(null);
+
     const [thumb, setThumb] = useState(null);
     const [photos, setPhotos] = useState(null);
     const [successMessage, setSuccessMessage] = useState('');
@@ -87,18 +93,23 @@ const CreatePost = () => {
         setSuccessMessage('');
         if (e.target.id === "doc1") {
             setdoc1(e.target.files[0]);
+            setdoc1name(e.target.files[0].name);
         } else if (e.target.id === "doc2") {
             setdoc2(e.target.files[0]);
+            setdoc2name(e.target.files[0].name);
         } else if (e.target.id === "doc3") {
             setdoc3(e.target.files[0]);
+            setdoc3name(e.target.files[0].name);
         } else if (e.target.id === "doc4") {
             setdoc4(e.target.files[0]);
+            setdoc4name(e.target.files[0].name);
         } else if (e.target.id === "doc5") {
             setdoc5(e.target.files[0]);
+            setdoc5name(e.target.files[0].name);
         } else if (e.target.id === "thumb") {
             setThumb(e.target.files[0]);
         } else if (e.target.id === "photos") {
-            setPhotos(e.target.files[0]);
+            setPhotos(Array.from(e.target.files));
         }
     };
 
@@ -114,12 +125,27 @@ const CreatePost = () => {
         // Special case for address
         formData.append('address', removeLastWordAndComma(address));
 
+        if (doc1) {
+            formData.append('doc1', doc1);
+            formData.append('doc1Name', doc1Name);
+        }
+        if (doc2) {
+            formData.append('doc2', doc2);
+            formData.append('doc2Name', doc2Name);
+        }
+        if (doc3) {
+            formData.append('doc3', doc3);
+            formData.append('doc3Name', doc3Name);
+        }
+        if (doc4) {
+            formData.append('doc4', doc4);
+            formData.append('doc4Name', doc4Name);
+        }
+        if (doc5) {
+            formData.append('doc5', doc5);
+            formData.append('doc5Name', doc5Name);
+        }
 
-        if (doc1) formData.append('doc1', doc1);
-        if (doc2) formData.append('doc2', doc2);
-        if (doc3) formData.append('doc3', doc3);
-        if (doc4) formData.append('doc4', doc4);
-        if (doc5) formData.append('doc5', doc5);
         if (thumb) formData.append('thumb', thumb);
         if (photos) {
             photos.forEach((photo, index) => {

--- a/src/components/createpost/edit-post.jsx
+++ b/src/components/createpost/edit-post.jsx
@@ -90,7 +90,7 @@ const CreatePost = () => {
                     <div className="listing">
                         <div className="listing-img" style={{ background: `url("${listing.thumb}") no-repeat center center` }} key={index}>    
                           <div className="address" style={{bottom: '25%'}}>{listing.name}</div>
-                          <div className="address">{listing.address}</div>
+                          <div className="address">{listing.altAddress ? listing.altAddress : listing.address}</div>
                           <div className="details">
                           <center style={{ display: 'flex', height: '100%', alignItems: 'center', justifyContent: 'center', gap: '1em' }}>
                                 <Link to={`/modifica/${listing.id}`}>

--- a/src/components/createpost/update-post.jsx
+++ b/src/components/createpost/update-post.jsx
@@ -302,23 +302,23 @@ if (!isLoaded) return <div>Loading...</div>;
                 <table>
                     <tbody>
                         <tr>
-                            <td><input className="fld" onChange={handleChange}  id="nameDoc1" type="text" value={post && post.nameDoc1 ? post.nameDoc1 : ''} placeholder={post && post.nameDoc1 ? '' : post.doc1Name}/></td>
+                            <td><input className="fld" onChange={handleChange}  id="nameDoc1" type="text" value={post && post.nameDoc1 ? post.nameDoc1 : ''} placeholder={post && post.nameDoc1 ? '' : (post && post.doc1Name ? post.doc1Name : 'documento 1')}/></td>
                             <td><input className="fld" onChange={handleFileChange}  id="doc1" type="file" /></td>
                         </tr>
                         <tr>
-                            <td><input className="fld" onChange={handleChange}  id="nameDoc2" type="text" value={post && post.nameDoc2 ? post.nameDoc2 : ''} placeholder={post && post.nameDoc2 ? '' : post.doc2Name}/></td>
+                            <td><input className="fld" onChange={handleChange}  id="nameDoc2" type="text" value={post && post.nameDoc2 ? post.nameDoc2 : ''} placeholder={post && post.nameDoc2 ? '' : (post && post.doc2Name ? post.doc2Name : 'documento 2')}/></td>
                             <td><input className="fld" onChange={handleFileChange}  id="doc2" type="file" /></td>
                         </tr>
                         <tr>
-                            <td><input className="fld" onChange={handleChange}  id="nameDoc3" type="text" value={post && post.nameDoc3 ? post.nameDoc3 : ''} placeholder={post && post.nameDoc3 ? '' : post.doc3Name}/></td>
+                            <td><input className="fld" onChange={handleChange}  id="nameDoc3" type="text" value={post && post.nameDoc3 ? post.nameDoc3 : ''} placeholder={post && post.nameDoc3 ? '' : (post && post.doc3Name ? post.doc3Name : 'documento 3')}/></td>
                             <td><input className="fld" onChange={handleFileChange}  id="doc3" type="file" /></td>
                         </tr>
                         <tr>
-                            <td><input className="fld" onChange={handleChange}  id="nameDoc4" type="text" value={post && post.nameDoc4 ? post.nameDoc4 : ''} placeholder={post && post.nameDoc4 ? '' : post.doc4Name}/></td>
+                            <td><input className="fld" onChange={handleChange}  id="nameDoc4" type="text" value={post && post.nameDoc4 ? post.nameDoc4 : ''} placeholder={post && post.nameDoc4 ? '' : (post && post.doc4Name ? post.doc4Name : 'documento 4')}/></td>
                             <td><input className="fld" onChange={handleFileChange}  id="doc4" type="file" /></td>
                         </tr>
                         <tr>
-                            <td><input className="fld" onChange={handleChange}  id="nameDoc5" type="text" value={post && post.nameDoc5 ? post.nameDoc5 : ''} placeholder={post && post.nameDoc5 ? '' : post.doc5Name}/></td>
+                            <td><input className="fld" onChange={handleChange}  id="nameDoc5" type="text" value={post && post.nameDoc5 ? post.nameDoc5 : ''} placeholder={post && post.nameDoc5 ? '' : (post && post.doc5Name ? post.doc5Name : 'documento 5')}/></td>
                             <td><input className="fld" onChange={handleFileChange}  id="doc5" type="file" /></td>
                         </tr>
                     </tbody>

--- a/src/components/createpost/update-post.jsx
+++ b/src/components/createpost/update-post.jsx
@@ -18,6 +18,12 @@ const [doc2, setdoc2] = useState(null);
 const [doc3, setdoc3] = useState(null);
 const [doc4, setdoc4] = useState(null);
 const [doc5, setdoc5] = useState(null);
+const [doc1Name, setdoc1name] = useState(null);
+const [doc2Name, setdoc2name] = useState(null);
+const [doc3Name, setdoc3name] = useState(null);
+const [doc4Name, setdoc4name] = useState(null);
+const [doc5Name, setdoc5name] = useState(null);
+
 const [thumb, setThumb] = useState(null);
 const [photos, setPhotos] = useState(null);
 const [successMessage, setSuccessMessage] = useState('');
@@ -98,14 +104,19 @@ const handleFileChange = (e) => {
     setSuccessMessage('');
     if (e.target.id === "doc1") {
         setdoc1(e.target.files[0]);
+        setdoc1name(e.target.files[0].name);
     } else if (e.target.id === "doc2") {
         setdoc2(e.target.files[0]);
+        setdoc2name(e.target.files[0].name);
     } else if (e.target.id === "doc3") {
         setdoc3(e.target.files[0]);
+        setdoc3name(e.target.files[0].name);
     } else if (e.target.id === "doc4") {
         setdoc4(e.target.files[0]);
+        setdoc4name(e.target.files[0].name);
     } else if (e.target.id === "doc5") {
         setdoc5(e.target.files[0]);
+        setdoc5name(e.target.files[0].name);
     } else if (e.target.id === "thumb") {
         setThumb(e.target.files[0]);
     } else if (e.target.id === "photos") {
@@ -124,11 +135,28 @@ const handleSubmit = async (e) => {
     formData.append('coordinates', coordinates ? [coordinates.lat, coordinates.lng] : post.coordinates);
     // Special case for address
     formData.append('address', address !== '' ? removeLastWordAndComma(address) : post.address);
-    if (doc1) formData.append('doc1', doc1);
-    if (doc2) formData.append('doc2', doc2);
-    if (doc3) formData.append('doc3', doc3);
-    if (doc4) formData.append('doc4', doc4);
-    if (doc5) formData.append('doc5', doc5);
+    
+    if (doc1) {
+        formData.append('doc1', doc1);
+        formData.append('doc1Name', doc1Name);
+    }
+    if (doc2) {
+        formData.append('doc2', doc2);
+        formData.append('doc2Name', doc2Name);
+    }
+    if (doc3) {
+        formData.append('doc3', doc3);
+        formData.append('doc3Name', doc3Name);
+    }
+    if (doc4) {
+        formData.append('doc4', doc4);
+        formData.append('doc4Name', doc4Name);
+    }
+    if (doc5) {
+        formData.append('doc5', doc5);
+        formData.append('doc5Name', doc5Name);
+    }
+
     if (thumb) formData.append('thumb', thumb);
     if (photos) {
         photos.forEach((photo, index) => {
@@ -274,23 +302,23 @@ if (!isLoaded) return <div>Loading...</div>;
                 <table>
                     <tbody>
                         <tr>
-                            <td><input className="fld" onChange={handleChange}  id="nameDoc1" type="text" value={post && post.nameDoc1 ? post.nameDoc1 : ''} placeholder={post && post.nameDoc1 ? '' : 'nome doc 1'}/></td>
+                            <td><input className="fld" onChange={handleChange}  id="nameDoc1" type="text" value={post && post.nameDoc1 ? post.nameDoc1 : ''} placeholder={post && post.nameDoc1 ? '' : post.doc1Name}/></td>
                             <td><input className="fld" onChange={handleFileChange}  id="doc1" type="file" /></td>
                         </tr>
                         <tr>
-                            <td><input className="fld" onChange={handleChange}  id="nameDoc2" type="text" value={post && post.nameDoc2 ? post.nameDoc2 : ''} placeholder={post && post.nameDoc2 ? '' : 'nome doc 2'}/></td>
+                            <td><input className="fld" onChange={handleChange}  id="nameDoc2" type="text" value={post && post.nameDoc2 ? post.nameDoc2 : ''} placeholder={post && post.nameDoc2 ? '' : post.doc2Name}/></td>
                             <td><input className="fld" onChange={handleFileChange}  id="doc2" type="file" /></td>
                         </tr>
                         <tr>
-                            <td><input className="fld" onChange={handleChange}  id="nameDoc3" type="text" value={post && post.nameDoc3 ? post.nameDoc3 : ''} placeholder={post && post.nameDoc3 ? '' : 'nome doc 3'}/></td>
+                            <td><input className="fld" onChange={handleChange}  id="nameDoc3" type="text" value={post && post.nameDoc3 ? post.nameDoc3 : ''} placeholder={post && post.nameDoc3 ? '' : post.doc3Name}/></td>
                             <td><input className="fld" onChange={handleFileChange}  id="doc3" type="file" /></td>
                         </tr>
                         <tr>
-                            <td><input className="fld" onChange={handleChange}  id="nameDoc4" type="text" value={post && post.nameDoc4 ? post.nameDoc4 : ''} placeholder={post && post.nameDoc4 ? '' : 'nome doc 4'}/></td>
+                            <td><input className="fld" onChange={handleChange}  id="nameDoc4" type="text" value={post && post.nameDoc4 ? post.nameDoc4 : ''} placeholder={post && post.nameDoc4 ? '' : post.doc4Name}/></td>
                             <td><input className="fld" onChange={handleFileChange}  id="doc4" type="file" /></td>
                         </tr>
                         <tr>
-                            <td><input className="fld" onChange={handleChange}  id="nameDoc5" type="text" value={post && post.nameDoc5 ? post.nameDoc5 : ''} placeholder={post && post.nameDoc5 ? '' : 'nome doc 5'}/></td>
+                            <td><input className="fld" onChange={handleChange}  id="nameDoc5" type="text" value={post && post.nameDoc5 ? post.nameDoc5 : ''} placeholder={post && post.nameDoc5 ? '' : post.doc5Name}/></td>
                             <td><input className="fld" onChange={handleFileChange}  id="doc5" type="file" /></td>
                         </tr>
                     </tbody>

--- a/src/components/createpost/update-post.jsx
+++ b/src/components/createpost/update-post.jsx
@@ -11,7 +11,7 @@ let { updateSlug } = useParams();
 const [listingsData, setListingsData] = useState([]);
 const [isSubmitting, setIsSubmitting] = useState(false);
 
-const [post, setPost] = useState(null);
+const [post, setPost] = useState('');
 
 const [doc1, setdoc1] = useState(null);
 const [doc2, setdoc2] = useState(null);
@@ -175,6 +175,7 @@ const handleSubmit = async (e) => {
 
 
 let squareMeters = 'm\u00B2';
+const [isCheckboxChecked, setCheckboxChecked] = useState(false);
 
 if (!isLoaded) return <div>Loading...</div>;
 
@@ -201,11 +202,11 @@ if (!isLoaded) return <div>Loading...</div>;
                     <tbody>
                         <tr>
                             <td className="lbl"><label htmlFor="name">Titolo:</label></td>
-                            <td><input className="fld" onChange={handleChange}  id="name" type="text" placeholder={post ? post.name : "Casa indipendente"}/></td>
+                            <td><input className="fld" onChange={handleChange}  id="name" type="text" value={post && post.name ? post.name : ''} placeholder={post && post.name ? '' : 'Casa indipendente'}/></td>
                         </tr>
                         <tr>
                             <td className="lbl"><label htmlFor="description">Descrizione:</label></td>
-                            <td><textarea style={{ width: '100%'}} onChange={handleChange}  id="description" type="text" placeholder={post ? post.description : "..."} /></td>
+                            <td><textarea style={{ width: '100%'}} onChange={handleChange}  id="description" type="text" value={post && post.description ? post.description : ''} placeholder={post && post.description ? '' : '...'} /></td>
                             <td></td>
                         </tr>
                         <tr>
@@ -225,12 +226,24 @@ if (!isLoaded) return <div>Loading...</div>;
                                 />
                             </Autocomplete>
                             </td>
-                            {/* <td><input className="fld" onChange={handleChange}  id="address" type="text" placeholder="Via/Piazza/Strada" /></td> */}
                         </tr>
-                        {/* <tr>
-                            <td className="lbl"><label htmlFor="floorSpace">Superficie:</label></td>
-                            <td><input className="fld" onChange={handleChange}  id="floorSpace" type="text" placeholder={squareMeters}/></td>
-                        </tr> */}
+                        <tr>
+                        <td className="lbl" style={{ display: 'flex', alignItems: 'center' }}>
+                            <label htmlFor="modifyAddress" style={{ marginRight: '0.5em' }}>Modifica indirizzo</label>
+                            <input type="checkbox" id="modifyAddress" onChange={() => {
+                                setCheckboxChecked(!isCheckboxChecked);
+                                if (isCheckboxChecked) {
+                                    setPost(prevPost => ({ ...prevPost, altAddress: '' }));
+                                }
+                            }} />
+                        </td>
+                            <td>
+                                {isCheckboxChecked && (
+                                    <input style={{ width: '100%'}} onChange={handleChange}  id="altAddress" type="text" placeholder={post ? (post.altAddress ? post.altAddress : post.address) : "Via/Piazza/Strada"} />
+                                )}
+                            </td>
+                            
+                        </tr>
                     </tbody>
                 </table>
             </div>
@@ -240,11 +253,11 @@ if (!isLoaded) return <div>Loading...</div>;
                     <tbody>
                         <tr>
                             <td className="lbl"><label htmlFor="locali">Locali:</label></td>
-                            <td><input className="fld" onChange={handleChange}  id="locali" type="text" placeholder={post ? post.locali : "0, 3-5"} /></td>
+                            <td><input className="fld" onChange={handleChange}  id="locali" type="text" value={post && post.locali ? post.locali : ''} placeholder={post && post.locali ? '' : '0, 3-5'} /></td>
                         </tr>
                         <tr>
                             <td className="lbl"><label htmlFor="floorSpace">Superficie:</label></td>
-                            <td><input className="fld" onChange={handleChange}  id="floorSpace" type="text" placeholder={post ? post.floorSpace : {squareMeters}}/></td>
+                            <td><input className="fld" onChange={handleChange}  id="floorSpace" type="text" value={post && post.floorSpace ? post.floorSpace : ''} placeholder={post && post.floorSpace ? '' : {squareMeters}}/></td>
                         </tr>
                         {/* <tr>
                             <td className="lbl"><label htmlFor="city">Città:</label></td>
@@ -256,7 +269,7 @@ if (!isLoaded) return <div>Loading...</div>;
                         </tr> */}
                         <tr>
                             <td className="lbl"><label htmlFor="other">Altro:</label></td>
-                            <td><input className="fld" onChange={handleChange}  id="other" type="text" placeholder={post ? post.other : "Giardino, ascensore..."}/></td>
+                            <td><input className="fld" onChange={handleChange}  id="other" type="text" value={post && post.other ? post.other : ''} placeholder={post && post.other ? '' : 'Giardino, ascensore...'}/></td>
                         </tr>
                     </tbody>
                 </table>
@@ -270,23 +283,23 @@ if (!isLoaded) return <div>Loading...</div>;
                 <table>
                     <tbody>
                         <tr>
-                            <td><input className="fld" onChange={handleChange}  id="nameDoc1" type="text" placeholder={post ? post.nameDoc1 : "nome doc 1"}/></td>
+                            <td><input className="fld" onChange={handleChange}  id="nameDoc1" type="text" value={post && post.nameDoc1 ? post.nameDoc1 : ''} placeholder={post && post.nameDoc1 ? '' : 'nome doc 1'}/></td>
                             <td><input className="fld" onChange={handleFileChange}  id="doc1" type="file" /></td>
                         </tr>
                         <tr>
-                            <td><input className="fld" onChange={handleChange}  id="nameDoc2" type="text" placeholder={post ? post.nameDoc2 : "nome doc 2"}/></td>
+                            <td><input className="fld" onChange={handleChange}  id="nameDoc2" type="text" value={post && post.nameDoc2 ? post.nameDoc2 : ''} placeholder={post && post.nameDoc2 ? '' : 'nome doc 2'}/></td>
                             <td><input className="fld" onChange={handleFileChange}  id="doc2" type="file" /></td>
                         </tr>
                         <tr>
-                            <td><input className="fld" onChange={handleChange}  id="nameDoc3" type="text" placeholder={post ? post.nameDoc3 : "nome doc 3"}/></td>
+                            <td><input className="fld" onChange={handleChange}  id="nameDoc3" type="text" value={post && post.nameDoc3 ? post.nameDoc3 : ''} placeholder={post && post.nameDoc3 ? '' : 'nome doc 3'}/></td>
                             <td><input className="fld" onChange={handleFileChange}  id="doc3" type="file" /></td>
                         </tr>
                         <tr>
-                            <td><input className="fld" onChange={handleChange}  id="nameDoc4" type="text" placeholder={post ? post.nameDoc4 : "nome doc 4"}/></td>
+                            <td><input className="fld" onChange={handleChange}  id="nameDoc4" type="text" value={post && post.nameDoc4 ? post.nameDoc4 : ''} placeholder={post && post.nameDoc4 ? '' : 'nome doc 4'}/></td>
                             <td><input className="fld" onChange={handleFileChange}  id="doc4" type="file" /></td>
                         </tr>
                         <tr>
-                            <td><input className="fld" onChange={handleChange}  id="nameDoc5" type="text" placeholder={post ? post.nameDoc5 : "nome doc 5"}/></td>
+                            <td><input className="fld" onChange={handleChange}  id="nameDoc5" type="text" value={post && post.nameDoc5 ? post.nameDoc5 : ''} placeholder={post && post.nameDoc5 ? '' : 'nome doc 5'}/></td>
                             <td><input className="fld" onChange={handleFileChange}  id="doc5" type="file" /></td>
                         </tr>
                     </tbody>
@@ -329,7 +342,7 @@ if (!isLoaded) return <div>Loading...</div>;
                         </tr>
                         <tr>
                             <td className="lbl"><label htmlFor="map">Link video:</label></td>
-                            <td><input className="fld" onChange={handleChange}  id="video" type="text" placeholder={post ? post.video : "..."}/></td>
+                            <td><input className="fld" onChange={handleChange}  id="video" type="text" value={post && post.video ? post.video : ''} placeholder={post && post.video ? '' : '...'}/></td>
                         </tr>
                     </tbody>
                 </table>

--- a/src/components/createpost/update-post.jsx
+++ b/src/components/createpost/update-post.jsx
@@ -188,15 +188,6 @@ if (!isLoaded) return <div>Loading...</div>;
         <form onSubmit={handleSubmit} encType="multipart/form-data">
         <fieldset>
             <legend>Proprietà</legend>
-            {/* <table>
-                <tbody>
-                    <tr>
-                        <td className="lbl"><label htmlFor="description">Descrizione:</label></td>
-                        <td><textarea style={{ width: '100%'}} onChange={handleChange}  id="description" type="text" placeholder="..." /></td>
-                        <td></td>
-                    </tr>
-                </tbody>
-            </table> */}
             <div className="frm">
                 <table>
                     <tbody>

--- a/src/components/createpost/update-post.jsx
+++ b/src/components/createpost/update-post.jsx
@@ -230,7 +230,7 @@ if (!isLoaded) return <div>Loading...</div>;
                         </td>
                             <td>
                                 {isCheckboxChecked && (
-                                    <input style={{ width: '100%'}} onChange={handleChange}  id="altAddress" type="text" placeholder={post ? (post.altAddress ? post.altAddress : post.address) : "Via/Piazza/Strada"} />
+                                    <input style={{ width: '100%'}} onChange={handleChange}  id="altAddress" type="text" value={post && post.altAddress ? post.altAddress : ''} placeholder={post && post.altAddress ? '' : post.address} />
                                 )}
                             </td>
                             

--- a/src/components/immobili/Immobili.jsx
+++ b/src/components/immobili/Immobili.jsx
@@ -61,7 +61,7 @@ const Immobili = () => {
                     <div className="listing">
                         <div className="listing-img" style={{ background: `url("${listing.thumb}") no-repeat center center`, backgroundSize: 'cover' }} key={index}>    
                           <div className="address" style={{bottom: '25%'}}>{listing.name}</div>
-                          <div className="address">{listing.address}</div>
+                          <div className="address">{listing.altAddress ? listing.altAddress : listing.address}</div>
                           <div className="details">
                             {/* <div className="my-col">
                               <img className="user-img-box" src={listing.userImg} alt="" />
@@ -72,7 +72,7 @@ const Immobili = () => {
                               </div>
                               <div className="listing-details">
                                 <div className="floor-space">
-                                  {listing.address}
+                                  {listing.altAddress ? listing.altAddress : listing.address}
                                 </div>
                                 {/* <hr style={{color: 'var(--selection-color)'}}/> */}
                                 <span className="floor-space">

--- a/src/components/immobili/Immobili.jsx
+++ b/src/components/immobili/Immobili.jsx
@@ -30,11 +30,16 @@ const Immobili = () => {
                 </center>
             </div>
             <section className="listings-results">
+            <center>
                 <h2 >
-                    <center>
-                        Nessun immobile trovato
-                    </center>
+                    Caricamento immobili...
                 </h2>
+                <div className="spinner">
+                    <div className="bounce1"></div>
+                    <div className="bounce2"></div>
+                    <div className="bounce3"></div>
+                </div>
+              </center>
             </section>
       </section>
     );

--- a/src/components/immobili/ImmobiliPostPage.jsx
+++ b/src/components/immobili/ImmobiliPostPage.jsx
@@ -152,57 +152,63 @@ const BlogPostPage = () => {
             <div className="message-title">
               <center>
                 <h1 >
-                {post ? <span className="message-title">{post.address}</span> : 'Loading...'}
+                {post ? <span className="message-title">{post.altAddress ? post.altAddress : post.address}</span> : 'Loading...'}
                 </h1>
               </center>
             </div>
             <div className="case"> 
                 <p>
-                  {post ? `${post.locali} locali | ${post.floorSpace} ${squareMeters}` : 'Loading...'}
+                  {post && post.locali ? `${post.locali} locali |` : '' }{post && post.floorSpace ? `${post.floorSpace} ${squareMeters}` : ''}
                 </p>
             </div>
       <div className='parent-container'>
         <div className='post-page-container'>
             
-            <div className="case"
+        <div className="case"
             style={{
-              textAlign: "left"}}
+                textAlign: "left"}}
             >
-                <h2 >
-                  Descrizione
-                </h2>
-                <p>
-                  {post ? post.description : 'Loading...'}
-                </p>
-            </div>
+            <h2>
+                Descrizione
+            </h2>
+            <p>
+                {post ? post.description.split('\n').map((item, key) => {
+                    return <span key={key}>{item}<br/></span>
+                }) : 'Loading...'}
+            </p>
+        </div>
 
+            {post && post.other && (
+              <div className="case"
+              style={{
+                textAlign: "left",
+                marginTop: "2em"
+              }}
+              >
+                  <h2 >
+                    Altre informazioni
+                  </h2>
+                  <p>
+                    {post.other}
+                  </p>
+              </div>
+            )}
+
+            
+            
             <div className="case"
             style={{
               textAlign: "left",
               marginTop: "2em"
             }}
             >
-                <h2 >
-                  Altre informazioni
-                </h2>
-                <p>
-                  {post ? post.other : 'Loading...'}
-                </p>
-            </div>
-
-            <hr />
-            <div className="case"
-            style={{
-              textAlign: "left",
-              marginTop: "2em"
-            }}
-            >
-                <h2 >
-                  Documentazione
-                </h2>
                 <div>
-                {post && (
+                {post && (post.doc1 || post.doc2 || post.doc3 || post.doc4 || post.doc5) && (
                           <div>
+                            <hr />
+                            <h2 >
+                              Documentazione
+                            </h2>
                             {post.doc1 && (
                             <div style={{ display: 'flex' }} onClick={() => downloadFile(post.doc1)}>
                               <span className='download-btn'> </span>

--- a/src/components/immobili/ImmobiliPostPage.jsx
+++ b/src/components/immobili/ImmobiliPostPage.jsx
@@ -151,8 +151,19 @@ const BlogPostPage = () => {
 
             <div className="message-title">
               <center>
-                <h1 >
-                {post ? <span className="message-title">{post.altAddress ? post.altAddress : post.address}</span> : 'Caricamento...'}
+                <h1>
+                    {post ? 
+                        <span className="message-title">{post.altAddress ? post.altAddress : post.address}</span> 
+                        : 
+                        <div>
+                            Caricamento...
+                            <div className="spinner">
+                                <div className="bounce1"></div>
+                                <div className="bounce2"></div>
+                                <div className="bounce3"></div> 
+                            </div>
+                        </div>
+                    }
                 </h1>
               </center>
             </div>
@@ -164,18 +175,22 @@ const BlogPostPage = () => {
       <div className='parent-container'>
         <div className='post-page-container'>
             
-        <div className="case"
-            style={{
-                textAlign: "left"}}
-            >
-            <h2>
-                Descrizione
-            </h2>
-            <p>
+        <div className="case" style={{textAlign: "left"}}>
+            <h2>Descrizione</h2>
+            <div>
                 {post ? post.description.split('\n').map((item, key) => {
                     return <span key={key}>{item}<br/></span>
-                }) : 'Caricamento...'}
-            </p>
+                }) : 
+                <div>
+                    Caricamento...
+                    <div className="spinner">
+                        <div className="bounce1"></div>
+                        <div className="bounce2"></div>
+                        <div className="bounce3"></div> 
+                    </div>
+                </div>
+                }
+            </div>
         </div>
 
             {post && post.other && (

--- a/src/components/immobili/ImmobiliPostPage.jsx
+++ b/src/components/immobili/ImmobiliPostPage.jsx
@@ -158,7 +158,7 @@ const BlogPostPage = () => {
             </div>
             <div className="case"> 
                 <p>
-                  {post && post.locali ? `${post.locali} locali |` : '' }{post && post.floorSpace ? `${post.floorSpace} ${squareMeters}` : ''}
+                  {post && post.locali ? `${post.locali} locali | ` : '' }{post && post.floorSpace ? `${post.floorSpace} ${squareMeters}` : ''}
                 </p>
             </div>
       <div className='parent-container'>
@@ -212,31 +212,31 @@ const BlogPostPage = () => {
                             {post.doc1 && (
                             <div style={{ display: 'flex' }} onClick={() => downloadFile(post.doc1)}>
                               <span className='download-btn'> </span>
-                              <span style={{lineHeight: '2em', cursor: 'pointer'}}> {post.nameDoc1 ? post.nameDoc1 : "Documento"}</span>
+                              <span style={{lineHeight: '2em', cursor: 'pointer'}}> {post.nameDoc1 ? post.nameDoc1 : post.doc1Name}</span>
                             </div>
                             )}
                             {post.doc2 && (
                             <div style={{ display: 'flex' }} onClick={() => downloadFile(post.doc2)}>
                               <span className='download-btn'> </span>
-                              <span style={{lineHeight: '2em', cursor: 'pointer'}}> {post.nameDoc2 ? post.nameDoc2 : "Documento"}</span>
+                              <span style={{lineHeight: '2em', cursor: 'pointer'}}> {post.nameDoc2 ? post.nameDoc2 : post.doc2Name}</span>
                             </div>
                             )}
                             {post.doc3 && (
                             <div style={{ display: 'flex' }} onClick={() => downloadFile(post.doc3)}>
                               <span className='download-btn'> </span>
-                              <span style={{lineHeight: '2em', cursor: 'pointer'}}> {post.nameDoc3 ? post.nameDoc3 : "Documento"}</span>
+                              <span style={{lineHeight: '2em', cursor: 'pointer'}}> {post.nameDoc3 ? post.nameDoc3 : post.doc3Name}</span>
                             </div>
                             )}
                             {post.doc4 && (
                             <div style={{ display: 'flex' }} onClick={() => downloadFile(post.doc4)}>
                               <span className='download-btn'> </span>
-                              <span style={{lineHeight: '2em', cursor: 'pointer'}}> {post.nameDoc4 ? post.nameDoc4 : "Documento"}</span>
+                              <span style={{lineHeight: '2em', cursor: 'pointer'}}> {post.nameDoc4 ? post.nameDoc4 : post.doc4Name}</span>
                             </div>
                             )}
                             {post.doc5 && (
                             <div style={{ display: 'flex' }} onClick={() => downloadFile(post.doc5)}>
                               <span className='download-btn'> </span>
-                              <span style={{lineHeight: '2em', cursor: 'pointer'}}> {post.nameDoc5 ? post.nameDoc5 : "Documento"}</span>
+                              <span style={{lineHeight: '2em', cursor: 'pointer'}}> {post.nameDoc5 ? post.nameDoc5 : post.doc5Name}</span>
                             </div>
                             )}
                           </div>

--- a/src/components/immobili/ImmobiliPostPage.jsx
+++ b/src/components/immobili/ImmobiliPostPage.jsx
@@ -103,7 +103,7 @@ const BlogPostPage = () => {
         document.body.removeChild(anchor);
         window.URL.revokeObjectURL(blobUrl);
     } catch (error) {
-        console.error('Error downloading the file:', error);
+        console.error('Error downCaricamento the file:', error);
     }
   };
 
@@ -152,7 +152,7 @@ const BlogPostPage = () => {
             <div className="message-title">
               <center>
                 <h1 >
-                {post ? <span className="message-title">{post.altAddress ? post.altAddress : post.address}</span> : 'Loading...'}
+                {post ? <span className="message-title">{post.altAddress ? post.altAddress : post.address}</span> : 'Caricamento...'}
                 </h1>
               </center>
             </div>
@@ -174,7 +174,7 @@ const BlogPostPage = () => {
             <p>
                 {post ? post.description.split('\n').map((item, key) => {
                     return <span key={key}>{item}<br/></span>
-                }) : 'Loading...'}
+                }) : 'Caricamento...'}
             </p>
         </div>
 

--- a/src/components/immobili/immobili.css
+++ b/src/components/immobili/immobili.css
@@ -316,3 +316,46 @@ font-weight: 700;
 background: #639;
 cursor: pointer;
 }
+
+
+.spinner {
+  margin: 100px auto;
+  width: 70px;
+  text-align: center;
+}
+
+.spinner > div {
+  width: 18px;
+  height: 18px;
+  background-color: var(--selection-b-color);
+
+  border-radius: 100%;
+  display: inline-block;
+  -webkit-animation: sk-bouncedelay 1.4s infinite ease-in-out both;
+  animation: sk-bouncedelay 1.4s infinite ease-in-out both;
+}
+
+.spinner .bounce1 {
+  -webkit-animation-delay: -0.32s;
+  animation-delay: -0.32s;
+}
+
+.spinner .bounce2 {
+  -webkit-animation-delay: -0.16s;
+  animation-delay: -0.16s;
+}
+
+@-webkit-keyframes sk-bouncedelay {
+  0%, 80%, 100% { -webkit-transform: scale(0) }
+  40% { -webkit-transform: scale(1.0) }
+}
+
+@keyframes sk-bouncedelay {
+  0%, 80%, 100% { 
+    -webkit-transform: scale(0);
+    transform: scale(0);
+  } 40% { 
+    -webkit-transform: scale(1.0);
+    transform: scale(1.0);
+  }
+}


### PR DESCRIPTION
Generali
  - Il testo nella descrizione degli immobili ora mostra le andate a capo.
Sezione Modifica
  - Quando si modifica un immobile, i campi vengono pre-compilati con il testo, in modo da essere immediatamente modificabili senza dover riscrivere tutto.
  - Una volta che l'indirizzo viene scelto dal menu a tendina, appare un tasto che permette di impostare un indirizzo personalizzato. Questo succede anche durante l'aggiunta di un immobile, non solo nella modifica. Ad esempio, adesso nell'immobile del Corletto, l'indirizzo che viene riportato e' "Strada Corletto Sud, 406" invece di "Str. Corletto Sud, 406, Modena MO"

Sezione Crea
  - Se non specificato nessun nome per i documenti, viene usato il nome del file (ad esempio, in corletto ora i file hanno i nomi "ABITAZIONE mapp. 63" etc)